### PR TITLE
fall back to checking url for environment when param parsing fails

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -41,7 +41,10 @@ export default Route.extend({
     },
 
     extractSDKParams() {
-        const search = window.location.search;
+        let environment = '';
+        const { search, hostname } = window.location;
+
+        // Parse environment from query params provided by apps framework
         if (search) {
             try {
                 const parameters = {};
@@ -50,13 +53,36 @@ export default Route.extend({
                     parameters[key] = value;
                 });
 
-                const application = this.get('application');
                 if (parameters.pcEnvironment) {
-                    application.set('environment', parameters.pcEnvironment);
+                    environment = parameters.pcEnvironment;
                 }
+
             } catch (error) {
-                Ember.Logger.error('Error parsing SDK parameters:', { error });
+                Ember.Logger.error('Error parsing SDK parameters:', {error});
             }
+        }
+
+        // default to url parsing when query params fails
+        if (!environment) {
+            // dca
+            if (hostname === 'apps.inindca.com') {
+                environment = 'inindca.com';
+            } else if (hostname === 'localhost') {
+                environment = 'inindca.com';
+            }
+            // tca
+            else if (hostname === 'apps.inintca.com') {
+                environment = 'inintca.com';
+            }
+            // prod
+            else {
+                let [_, host] = hostname.split('apps.');
+                environment = host;
+            }
+        }
+
+        if (environment) {
+            this.get('application').set('environment', environment);
         }
     }
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -20,7 +20,7 @@ export default Route.extend({
     beforeModel() {
         const ref = window.location.href;
         const tokenIndex = ref.indexOf('access_token');
-        const stateIndex = ref.indexOf('session_state')
+        const stateIndex = ref.indexOf('session_state');
         const auth = this.get('auth');
 
         const isPurecloudAuth = tokenIndex > 0 && stateIndex === -1;


### PR DESCRIPTION
An issue with apps sdk is causing the url provided by the sdk to have it's query parameters stripped by amazon. This provides a fallback to parse the environment when one cannot be found from query params, but prefers the one provided by the sdk when available.